### PR TITLE
Symbolic link relative to link location

### DIFF
--- a/automydumper
+++ b/automydumper
@@ -205,7 +205,7 @@ function verify_backups()
 function symlink_latest()
 {
     rm -f "${backup_root_dir}/latest"
-    ln -sf "${backup_dir}" "${backup_root_dir}/latest"
+    ln -sfr "${backup_dir}" "${backup_root_dir}/latest"
 }
 
 # Stop the script when it's disabled by the user.


### PR DESCRIPTION
Create 'latest' symbolic link relative to backup location.
Useful when rsync-ing backups to other location.